### PR TITLE
'apiary preview --output FILE' to fetch HTML

### DIFF
--- a/lib/apiary/cli.rb
+++ b/lib/apiary/cli.rb
@@ -24,6 +24,10 @@ module Apiary
           options[:path] = path
         end
 
+        opts.on("--output [PATH]") do |path|
+          options[:output]  = path
+        end
+
         opts.on("--api_host API_HOST") do |api_host|
           options[:api_host] = api_host
         end

--- a/lib/apiary/command/preview.rb
+++ b/lib/apiary/command/preview.rb
@@ -81,10 +81,16 @@ module Apiary
         exec "open #{browser_options} #{path}"
       end
 
+      def write_generated_path(path, outfile)
+        File.open(outfile, 'w') do |file|
+          file.write(File.open(path, 'r').read)
+        end
+      end
+
       def generate_static(path)
         File.open(preview_path(path), "w") do |file|
           file.write(query_apiary(@options.api_host, path))
-          open_generated_page(file.path)
+          @options.output ? write_generated_path(file.path, @options.output) : open_generated_page(file.path)
         end
       end
 


### PR DESCRIPTION
These changes implement a minor convenience feature: fetch the HTML generated by the preview operation.
