### PR TITLE
Eliminate bogus failed with 200

### DIFF
--- a/lib/honey/command/publish.rb
+++ b/lib/honey/command/publish.rb
@@ -59,7 +59,7 @@ module Honey
         }
         response = RestClient.post url, data, @options.headers
 
-        unless response.code == 201
+        unless (200..299).include? response.code
           abort "Request failed with code #{response.code}"
         end
       end


### PR DESCRIPTION
`honey publish` fails, reporting

```
Request failed with code 200
```

if you're updating a Blueprint that already exists.

This  patch treats all HTTP Status 2xx as "success" (which, indeed, is what the HTTP standard says).
