### PR TITLE
Proxy is now set from http_proxy environment variable

### DIFF
--- a/lib/apiary/command/fetch.rb
+++ b/lib/apiary/command/fetch.rb
@@ -19,6 +19,7 @@ module Apiary
         @options.port         ||= 8080
         @options.api_name     ||= false
         @options.api_key      ||= ENV['APIARY_API_KEY']
+        @options.proxy        ||= ENV['http_proxy']
         @options.headers      ||= {
           :accept => "text/html",
           :content_type => "text/plain",
@@ -56,6 +57,7 @@ module Apiary
 
       def query_apiary(host, path)
         url  = "https://#{host}/blueprint/get/#{@options.api_name}"
+        RestClient.proxy = @options.proxy
         response = RestClient.get url, @options.headers        
         unless (200..299).include? response.code
           abort "Request failed with code #{response.code}"

--- a/lib/apiary/command/preview.rb
+++ b/lib/apiary/command/preview.rb
@@ -23,6 +23,7 @@ module Apiary
         @options.api_host     ||= "api.apiary.io"
         @options.headers      ||= {:accept => "text/html", :content_type => "text/plain"}
         @options.port         ||= 8080
+        @options.proxy        ||= ENV['http_proxy']
       end
 
       def self.execute(args)
@@ -73,6 +74,7 @@ module Apiary
       def query_apiary(host, path)
         url  = "https://#{host}/blueprint/generate"
         data = File.read(path)
+        RestClient.proxy = @options.proxy
         RestClient.post(url, data, @options.headers)
       end
 

--- a/lib/apiary/command/publish.rb
+++ b/lib/apiary/command/publish.rb
@@ -18,6 +18,7 @@ module Apiary
         @options.port         ||= 8080
         @options.api_name     ||= false
         @options.api_key      ||= ENV['APIARY_API_KEY']
+        @options.proxy        ||= ENV['http_proxy']
         @options.headers      ||= {
           :accept => "text/html",
           :content_type => "text/plain",
@@ -57,6 +58,7 @@ module Apiary
         data = {
           :code => File.read(path)
         }
+        RestClient.proxy = @options.proxy
         response = RestClient.post url, data, @options.headers
 
         unless (200..299).include? response.code


### PR DESCRIPTION
This pull request contains a fix for issue #27. It allows access to the apiary API via a proxy server using the "http_proxy" environment variable. 

Tested working behind company proxy server.
