### PR TITLE
Propagating of errors from the Apiary.io service

### DIFF
--- a/lib/apiary/command/fetch.rb
+++ b/lib/apiary/command/fetch.rb
@@ -24,11 +24,11 @@ module Apiary
           :accept => "text/html",
           :content_type => "text/plain",
           :authentication => "Token #{@options.api_key}"
-        }        
+        }
       end
 
       def self.execute(args)
-        response = new(args).fetch_from_apiary        
+        response = new(args).fetch_from_apiary
         if response.instance_of? String
           puts response
         end
@@ -58,10 +58,13 @@ module Apiary
       def query_apiary(host, path)
         url  = "https://#{host}/blueprint/get/#{@options.api_name}"
         RestClient.proxy = @options.proxy
-        response = RestClient.get url, @options.headers        
-        unless (200..299).include? response.code
-          abort "Request failed with code #{response.code}"
-        end        
+
+        begin
+          response = RestClient.get url, @options.headers
+        rescue RestClient::Exception => e
+          abort "Apiary service responded with an error: #{e.message}"
+        end
+
         JSON.parse response.body
       end
 


### PR DESCRIPTION
Closes #20.

Those `unless (200..299).include? response.code` statements would never get to be executed anyway, because `RestClient` raises exceptions in case the response code isn't okay.

Not sure if there's documentation to the Apiary.io service - I just inspected the responses and tried to get the best from them (unfortunately, no line/character info is available, so those new error messages are not actually very helpful anyway for debugging the blueprint).

If preview server is running, it logs the stacktrace of `abort` statements and continues to run. I am not sure what is the best solution of that - I thought it should just shut down with the error message, but I couldn't get to that behaviour. I kept using `abort`s so it follows the convention I've seen in everywhere else the gem.

The code's not very DRY, but I feel still quite new to Ruby so I could refactor it into something more elegant.
