### PR TITLE
[Preview] Fix leaked file descriptor during writing

### DIFF
--- a/lib/apiary/command/preview.rb
+++ b/lib/apiary/command/preview.rb
@@ -108,9 +108,7 @@ module Apiary
       end
 
       def write_generated_path(path, outfile)
-        File.open(outfile, 'w') do |file|
-          file.write(File.open(path, 'r').read)
-        end
+        File.write(outfile, File.read(path))
       end
 
       def generate_static(path)


### PR DESCRIPTION
`File.open(path, 'r').read` leaks the file descriptor that is opened. Simplified logic to use `File.write` and `File.read` to stop leaking this file descriptor.
