### PR TITLE
Fixing hardcoded tmp path

### DIFF
--- a/lib/apiary/command/preview.rb
+++ b/lib/apiary/command/preview.rb
@@ -3,6 +3,7 @@ require 'rest_client'
 require 'rack'
 require 'ostruct'
 require 'json'
+require 'tmpdir'
 
 require "apiary/common"
 
@@ -74,7 +75,8 @@ module Apiary
 
       def preview_path(path)
         basename = File.basename(@options.path)
-        "/tmp/#{basename}-preview.html"
+        temp = Dir.tempdir()
+        "#{temp}/#{basename}-preview.html"
       end
 
       def query_apiary(host, path)

--- a/lib/apiary/command/preview.rb
+++ b/lib/apiary/command/preview.rb
@@ -75,7 +75,7 @@ module Apiary
 
       def preview_path(path)
         basename = File.basename(@options.path)
-        temp = Dir.tempdir()
+        temp = Dir.tmpdir()
         "#{temp}/#{basename}-preview.html"
       end
 


### PR DESCRIPTION
Temp path is hardcoded so it won't work on windows, this should now work across platforms