### PR TITLE
[Fetch] When output is `-` send to STDOUT

### DIFF
--- a/lib/apiary/command/fetch.rb
+++ b/lib/apiary/command/fetch.rb
@@ -42,7 +42,7 @@ module Apiary
         end
 
         response = self.query_apiary(@options.api_host, @options.path)
-        if @options.output
+        if @options.output && @options.output != '-'
           write_generated_path(response["code"], @options.output)
         else
           response["code"]


### PR DESCRIPTION
This is so that we can use `apiary fetch --output=-` to get the blueprint sent to STDOUT.

Required for https://github.com/kylef/apiblueprint.vim/pull/9