### PR TITLE
Feature/pulls 78 87 94 enhance readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,83 @@ look in how to use this tool.
 
 ## Usage
 
-    $ apiary help
-	Commands:
-	  apiary fetch --api-name=API_NAME    # Fetch apiary.apib from API_NAME.apiary.io
-	  apiary help [COMMAND]               # Describe available commands or one specific...
-	  apiary preview                      # Show API documentation in default browser
-	  apiary publish --api-name=API_NAME  # Publish apiary.apib on docs.API_NAME.apiary.io
-	  apiary version                      # Show version
+```
+$ apiary help
+Commands:
+  apiary fetch --api-name=API_NAME    # Fetch apiary.apib from API_NAME.apiary.io
+  apiary help [COMMAND]               # Describe available commands or one specific...
+  apiary preview                      # Show API documentation in default browser
+  apiary publish --api-name=API_NAME  # Publish apiary.apib on docs.API_NAME.apiary.io
+  apiary version                      # Show version
 
+```
 
-Further documentation is available with `apiary help COMMAND` and at the [full documentation](http://client.apiary.io) site.
+### Details
+
+#### fetch
+
+```
+$ apiary help fetch
+Usage:
+  apiary fetch --api-name=API_NAME
+
+Options:
+  --api-name=API_NAME  
+  [--api-host=HOST]    # Specify apiary host
+  [--output=FILE]      # Write apiary.apib into specified file
+
+Fetch apiary.apib from API_NAME.apiary.io
+```
+
+#### preview
+
+```
+$ apiary help preview
+Usage:
+  apiary preview
+
+Options:
+  [--browser=chrome|safari|firefox]  # Show API documentation in specified browser
+                                     # Possible values: chrome, safari, firefox
+  [--output=FILE]                    # Write generated HTML into specified file
+  [--path=PATH]                      # Specify path to blueprint file
+                                     # Default: apiary.apib
+  [--api-host=HOST]                  # Specify apiary host
+  [--server], [--no-server]          # Start standalone web server on port 8080
+  [--port=PORT]                      # Set port for --server option
+
+Show API documentation in default browser
+```
+
+#### publish
+
+```
+$ apiary help publish
+Usage:
+  apiary publish --api-name=API_NAME
+
+Options:
+  [--message=COMMIT_MESSAGE]  # Publish with custom commit message
+  [--path=PATH]               # Specify path to blueprint file
+                              # Default: apiary.apib
+  [--api-host=HOST]           # Specify apiary host
+  --api-name=API_NAME         
+
+Publish apiary.apib on docs.API_NAME.apiary.io
+```
+
+#### version
+
+```
+$ apiary help version
+Usage:
+  apiary version
+
+Options:
+  [--{:aliases=>"-v"}={:ALIASES=>"-V"}]  
+
+Show version
+```
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -34,26 +34,15 @@ look in how to use this tool.
 ## Usage
 
     $ apiary help
+	Commands:
+	  apiary fetch --api-name=API_NAME    # Fetch apiary.apib from API_NAME.apiary.io
+	  apiary help [COMMAND]               # Describe available commands or one specific...
+	  apiary preview                      # Show API documentation in default browser
+	  apiary publish --api-name=API_NAME  # Publish apiary.apib on docs.API_NAME.apiary.io
+	  apiary version                      # Show version
 
-    Usage: apiary command [options]
-    Try 'apiary help' for more information.
 
-    Currently available apiary commands are:
-
-      preview                                     Show API documentation in default browser
-      preview --browser [chrome|safari|firefox]   Show API documentation in specified browser
-      preview --output [FILE]                     Write generated HTML into specified file
-      preview --path [PATH]                       Specify path to blueprint file
-      preview --api_host [HOST]                   Specify apiary host
-      preview --server                            Start standalone web server on port 8080
-      preview --server --port [PORT]              Start standalone web server on specified port
-      publish --api-name [API_NAME]               Publish apiary.apib on docs.API_NAME.apiary.io
-      publish --api-name [API_NAME] \
-              --message [COMMIT_MESSAGE]          Publish with custom commit message
-      fetch   --api-name [API_NAME]               Fetch apiary.apib from API_NAME.apiary.io
-              --output [FILE]                     Write apiary.apib into specified file
-      help                                        Show this help
-      version                                     Show version
+Further documentation is available with `apiary help COMMAND` and at the [full documentation](http://client.apiary.io) site.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,49 @@
-apiaryio
-=============
+Apiary CLI Client
+=================
 
-Apiary.io CLI
+[Apiary](https://apiary.io) CLI client, `apiary`.
 
 [![Build Status](https://travis-ci.org/apiaryio/apiary-client.png?branch=master)](https://travis-ci.org/apiaryio/apiary-client) [![Build status](https://ci.appveyor.com/api/projects/status/0hmkivbnhf9p3f8d/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/apiary-client/branch/master)
 
+## Description
 
-## Install
+The Apiary CLI Client gem is a command line tool for developing and previewing
+[API Blueprint](http://apiblueprint.org) documents locally. It can also be
+used for pushing updated documents to and fetching existing documents from
+[Apiary](http://apiary.io).
 
-**install gem** (required)
-``` bash
+
+Please see the `apiary help` command and the [full documentation](http://client.apiary.io) for an in-depth look in how to use this tool.
+
+For instructions on making your  own changes, see [Hacking Apiary CLI Client](#hacking-apiary-cli-client), below.
+
+## Installation
+
+### Install as a Ruby gem
+
+``` sh
 gem install apiaryio
 ```
 
-**setup APIARY.io credentials** (required for publish and fetch command only)
+### Setup Apiary credentials
 
-1. Retrieve APIKEY on `https://login.apiary.io/tokens`
-2. Save it to your environment variables :
+*Required only for publish and fetch commands.*
 
-```bash
-export APIARY_API_KEY=<your_token_retrieved_on_step_1>
+
+1. Make sure you are a registered user of [Apiary](http://apiary.io).
+2. Retrieve API key (token) on [this page](https://login.apiary.io/tokens).
+3. Export it as an environment variable:
+
+```sh
+export APIARY_API_KEY=<your_token>
 ```
-
-## Description
-
-The Apiary CLI gem is a command line tool for developing and previewing
-API Blueprint documents locally. It can also be used for pushing
-updated documents to and fetching existing documents from Apiary.io.
-
-Please see the [full documentation](http://client.apiary.io) for an in-depth
-look in how to use this tool.
-
-## Usage
+## Command-line Usage
 
 ```
 $ apiary help
 Commands:
   apiary fetch --api-name=API_NAME    # Fetch apiary.apib from API_NAME.apiary.io
-  apiary help [COMMAND]               # Describe available commands or one specific...
+  apiary help [COMMAND]               # Describe available commands or one specific command
   apiary preview                      # Show API documentation in default browser
   apiary publish --api-name=API_NAME  # Publish apiary.apib on docs.API_NAME.apiary.io
   apiary version                      # Show version
@@ -111,27 +117,54 @@ Options:
 Show version
 ```
 
-## Copyright
+## Hacking Apiary CLI Client
 
-Copyright 2012-15 (c) Apiary Ltd.
+### Build
 
-## Contributors
+1.  If needed, install bundler:
 
-- Jakub Nešetřil
-- James Charles Russell [botanicus]
-- Lukáš Linhart [Almad]
-- Emili Parreño
-- Peter Grilli [Tu1ly]
-- Ladislav Prskavec
-- Honza Javorek
-- Matthew Rudy Jacobs
-- Adam Kliment
-- Jack Repenning
-- Peter Strapp
-- Pierre Merlin
-- František Hába
-- Benjamin Arthur Lupton
+    ```sh
+    $ gem install bundler
+    ```
+
+2.  Clone the repo:
+
+    ```sh
+    $ git clone git@github.com:apiaryio/apiary-client.git
+    $ cd apiary-client
+    ```
+
+3.  Install dependencies:
+
+    ```sh
+    $ bundle install
+    ```
+
+### Test
+
+Inside the `apiary-client` repository directory run:
+
+```sh
+$ bundle exec rake test
+$ bundle exec rake features
+```
+
+
+### Release
+
+Use `bundle install` to install your changes locally, for manual and ad-hock testing.
+Use `gem push` to
+release a new version (refer to [RubyGems docs](http://guides.rubygems.org/publishing/) for further information).
+
+```sh
+$ gem push apiaryio-X.X.X.gem
+```
+
 
 ## License
 
-Released under MIT license. See LICENSE file for further details.
+Copyright 2012-15 (c) Apiary Ltd.
+
+Released under MIT license.
+See [LICENSE](https://raw.githubusercontent.com/apiaryio/apiary-client/master/LICENSE) file for further details.
+

--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -1,7 +1,8 @@
 Feature: Fetch apiary.apib from API_NAME.apiary.io
 
   # This is integration testing you have to set APIARY_API_KEY
+  @needs_apiary_api_key
   Scenario: Fetch apiary.apib from API_NAME.apiary.io
 
-    When I run `apiary fetch --api-name apiaryclienttest`
+    When I run `apiary fetch --api-name testingapiaryclitestingapiarycli`
     Then the output should contain the content of file "apiary.apib"

--- a/features/preview.feature
+++ b/features/preview.feature
@@ -1,6 +1,7 @@
 Feature: Show API documentation in specified browser
 
   # This is integration testing you have to set APIARY_API_KEY
+  @needs_apiary_api_key
   Scenario: Write generated HTML into specified file
 
     When I run `apiary preview --path apiary.apib --output=test.html`

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -1,7 +1,9 @@
 Feature: Publish apiary.apib on docs.API_NAME.apiary.io
 
   # This is integration testing you have to set APIARY_API_KEY
+  @needs_apiary_api_key
   Scenario: Publish apiary.apib on docs.API_NAME.apiary.io
 
+    # expected to fail
     When I run `apiary publish --path=apiary.apib --api-name 1111apiaryclienttest`
     Then the exit status should be 1

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,3 +5,18 @@ Before do
   @dirs << "../../features/fixtures"
   ENV['PATH'] = "./bin#{File::PATH_SEPARATOR}#{ENV['PATH']}"  
 end
+
+Around('@needs_apiary_api_key') do |scenario, block|
+  # DEBUG puts "Scenario #{scenario.name} wants APIARY_API_KEY."
+  original_value = ENV.delete("APIARY_API_KEY");
+  ENV["APIARY_API_KEY"] = "340bda135034529ab2abf341295c3aa2" # XXX
+  block.call
+  ENV["APIARY_API_KEY"] = original_value
+end
+
+Around('@doesnt_need_apiary_api_key') do |scenario, block|
+  # DEBUG puts "Scenario #{scenario.name} doesn't want APIARY_API_KEY."
+  original_value = ENV.delete("APIARY_API_KEY");
+  block.call
+  ENV["APIARY_API_KEY"] = original_value
+end

--- a/features/support/setup.rb
+++ b/features/support/setup.rb
@@ -1,1 +1,5 @@
 require 'aruba/cucumber'
+
+Before('@needs_apiary_api_key') do
+  @aruba_timeout_seconds = 30
+end

--- a/features/support/setup.rb
+++ b/features/support/setup.rb
@@ -1,5 +1,5 @@
 require 'aruba/cucumber'
 
 Before('@needs_apiary_api_key') do
-  @aruba_timeout_seconds = 30
+  @aruba_timeout_seconds = 45
 end

--- a/features/version.feature
+++ b/features/version.feature
@@ -1,5 +1,6 @@
 Feature: Version of Apiary client
 
+  @doesnt_need_apiary_api_key
   Scenario: Print the semantic version of Apiary client
 
     # Note the output should be a semantic version (semver.org)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2,8 +2,24 @@ require 'spec_helper'
 
 describe Apiary::CLI do
 
-  it 'pass the test' do
-    expect(true).to be_truthy
+  it 'has help' do
+    helpcount = Kernel.open('|bin/apiary help') {|f| f.read}.lines.count
+    expect(helpcount).to be >= 5
+  end
+  
+  it 'includes help in README.md' do
+
+    begin
+      helpcount = Kernel.open('|bin/apiary help | tee help.out') {|f| f.read}.lines.count
+      expect(helpcount).to be >= 5 
+
+      matchcount = `diff -w -C1000 README.md help.out | grep '^ '`.lines.count
+      expect(matchcount).to eq(helpcount)
+
+    ensure
+      File.unlink('help.out')
+    end
+
   end
 
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -6,20 +6,28 @@ describe Apiary::CLI do
     helpcount = Kernel.open('|bin/apiary help') {|f| f.read}.lines.count
     expect(helpcount).to be >= 5
   end
-  
-  it 'includes help in README.md' do
 
-    begin
-      helpcount = Kernel.open('|bin/apiary help | tee help.out') {|f| f.read}.lines.count
-      expect(helpcount).to be >= 5 
+  (["",] +
+   `bin/apiary help`
+     .lines
+     .map {|l| /^ +apiary /.match(l)?l:nil}
+     .map {|l| /^ *apiary help/.match(l)?nil:l}
+     .compact
+     .map {|l| /^ *apiary ([^ ]*)/.match(l)[1] + " " }
+  ).each do |cmd|
 
-      matchcount = `diff -w -C1000 README.md help.out | grep '^ '`.lines.count
-      expect(matchcount).to eq(helpcount)
+    it "includes help #{cmd}in README.md" do
+      begin
+        helpfile="help#{cmd.strip}.out"
+        helptext = open("|bin/apiary help #{cmd} | tee #{helpfile}") {|f| f.read}
+        matchtext = `diff -w -C1000 README.md #{helpfile} | sed -n '/^  \\(.*\\)/s//\\1/p'`
 
-    ensure
-      File.unlink('help.out')
+        expect(matchtext).to eq(helptext)
+
+      ensure
+        !File.exist?(helpfile) || File.unlink(helpfile)
+      end
     end
-
   end
 
 end


### PR DESCRIPTION
This change includes and obsoletes three earlier Pull Requests:

* [#78](https://github.com/apiaryio/apiary-client/issues/78) Apiary help inconsistent
    * Include all capabilities in README.md
* [#87](https://github.com/apiaryio/apiary-client/pull/87) Facelift of README
    * Detailed "Hacking" instructions
    * Add tests to confirm help is all there
    * Make tests auto-detect added capabilities
* [#94](https://github.com/apiaryio/apiary-client/pull/94) Make README.md help output match cli.rb
    * Make tests work for anyone (not depend on user's
      APIARY_API_KEY)

Details may be seen on my [feature/Pulls-78-87-94-enhance-readme](https://github.com/jrep/apiary-client/tree/feature/Pulls-78-87-94-enhance-readme) branch
