### PR TITLE
Implement a host option for `apiary preview --server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Options:
   [--api-host=HOST]                  # Specify apiary host
   [--server], [--no-server]          # Start standalone web server on port 8080
   [--port=PORT]                      # Set port for --server option
+  [--host=HOST]                      # Set host for --server option
 
 Show API documentation in default browser
 ```

--- a/lib/apiary/cli.rb
+++ b/lib/apiary/cli.rb
@@ -24,6 +24,7 @@ module Apiary
     method_option :api_host, :type => :string, :banner => 'HOST', :desc => 'Specify apiary host'
     method_option :server, :type => :boolean, :desc => 'Start standalone web server on port 8080'
     method_option :port, :type => :numeric, :banner => 'PORT', :desc => 'Set port for --server option'
+    method_option :host, :type => :string, :desc => 'Set host for --server option'
 
     def preview
       cmd = Apiary::Command::Preview.new options

--- a/lib/apiary/command/preview.rb
+++ b/lib/apiary/command/preview.rb
@@ -34,6 +34,7 @@ module Apiary
         @options.port         ||= 8080
         @options.proxy        ||= ENV['http_proxy']
         @options.server       ||= false
+	@options.host	      ||= '127.0.0.1'
 
         validate_apib_file
       end
@@ -78,7 +79,7 @@ module Apiary
           generate
         end
 
-        Rack::Server.start(:Port => @options.port, :app => app)
+        Rack::Server.start(:Port => @options.port, :Host => @options.host, :app => app)
       end
 
       # TODO: add linux and windows systems


### PR DESCRIPTION
Hello,

### Premise: 
Whenever the `apiary preview --server` command is launched, it binds to the loopback device address: `127.0.0.1`.

This is a fine scenario for most development configurations; however it is sub-optimal when using visualization containers for DevOps.

### Issue
When the preview server is running within a virtualized context the loopback device isn't exposed.
As such the API preview isn't visible outside the container.

Our specific virtualization context is running `apiary` inside a docker container, and accessing it from the host machine.

### Resolution
This pull requests adds an option to the `apiary preview --server` command; namely to specify a hostname.

For virtualized contexts this will usually be binding to `0.0.0.0` rather than to `127.0.0.1`.

### Conclusion
This pull requests enables the visualization DevOps workflow, and the possibility of hosting the preview in-house.