### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
-FROM coopermaa/alpine-ruby:2.2-onbuild]
+FROM coopermaa/alpine-ruby:2.2
+RUN apk add --update build-base && rm /var/cache/apk/*
 RUN gem install apiaryio
 ENTRYPOINT ["apiary"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM coopermaa/alpine-ruby:2.2-onbuild]
+RUN gem install apiaryio
+ENTRYPOINT ["apiary"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ For instructions on making your  own changes, see [Hacking Apiary CLI Client](#h
 gem install apiaryio
 ```
 
+### Using Docker - alternative if you don't install ruby or installation not work for you
+
+Download image:
+
+```
+docker pull apiaryio/client
+```
+Run instead `apiary` just `docker run apiaryio/client`
+
+Build from source code:
+
+```
+docker build -t "apiaryio/client" .
+```
+
 ### Setup Apiary credentials
 
 *Required only for publish and fetch commands.*


### PR DESCRIPTION
`docker run apiaryio/client` now works as alternative for people who have problem with install gem for example at windows.