### PR TITLE
Loosen dependecy on rest-client

### DIFF
--- a/apiary.gemspec
+++ b/apiary.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Apiary::VERSION
 
-  gem.add_dependency "rest-client", "~> 1.8"
+  gem.add_dependency "rest-client", "~> 1.0"
   gem.add_dependency "rack", "~> 1.6.4"
   gem.add_dependency "rake", "~> 10.4"
   gem.add_dependency "thor", "~> 0.19.1"


### PR DESCRIPTION
We're using the apiary client to automatically publish documentation in our Rails app as part of each CI build in stating and production environments. We're using the library code directly as part of a rake task and not using the clie.

Some dependency in our app happens to use a version of `rest-client` that is < 1.8. Is there a specific feature in 1.8+ that is required or did this just happen to be the version of `rest-client` available when authoring the first time?