### PR TITLE
Fixes issue where message was not be passed on publish

### DIFF
--- a/lib/apiary/command/publish.rb
+++ b/lib/apiary/command/publish.rb
@@ -24,7 +24,7 @@ module Apiary
           :content_type => "text/plain",
           :authentication => "Token #{@options.api_key}"
         }
-        @options.commit_message ||= "Saving blueprint from apiary-client"
+        @options.message ||= "Saving blueprint from apiary-client"
       end
 
       def execute()
@@ -63,7 +63,7 @@ module Apiary
         if validate_apib_file path
           data = {
             :code => get_apib_file(path),
-            :messageToSave => @options.commit_message
+            :messageToSave => @options.message
           }
           RestClient.proxy = @options.proxy
 

--- a/spec/command/publish_spec.rb
+++ b/spec/command/publish_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Apiary::Command::Publish do
+  context 'when constructed without a message' do
+    it 'uses the default message' do
+      command = Apiary::Command::Publish.new({})
+      expect(command.options.message).to eq('Saving blueprint from apiary-client')
+    end
+  end
+
+  context 'when constructed with a message' do
+    it 'stores the message in the opts' do
+      command = Apiary::Command::Publish.new(:message => 'Custom message')
+      expect(command.options.message).to eq('Custom message')
+    end
+  end
+
+  describe '#execute' do
+    context 'when calling with a custom message' do
+      it 'sends the message when publishing' do
+        WebMock.stub_request(:post, 'https://api.apiary.io/blueprint/publish/myapi')
+        Apiary::Command::Publish.new(:api_name => 'myapi', :message => 'Custom message').execute
+        expect(WebMock).to have_requested(:post, 'https://api.apiary.io/blueprint/publish/myapi').
+          with {|request| request.body.include? 'messageToSave=Custom%20message'}
+      end
+    end
+  end
+end

--- a/spec/command/publish_spec.rb
+++ b/spec/command/publish_spec.rb
@@ -2,24 +2,44 @@ require 'spec_helper'
 
 describe Apiary::Command::Publish do
   context 'when constructed without a message' do
+    let(:message) do
+      Apiary::Command::Publish.new({
+        :api_name => 'myapi',
+        :path => './features/fixtures/apiary.apib'
+      }).options.message
+    end
+
     it 'uses the default message' do
-      command = Apiary::Command::Publish.new({})
-      expect(command.options.message).to eq('Saving blueprint from apiary-client')
+      expect(message).to eq('Saving blueprint from apiary-client')
     end
   end
 
   context 'when constructed with a message' do
+    let(:message) do
+      Apiary::Command::Publish.new({
+        :api_name => 'myapi',
+        :message => 'Custom message',
+        :path => './features/fixtures/apiary.apib'
+      }).options.message
+    end
+
     it 'stores the message in the opts' do
-      command = Apiary::Command::Publish.new(:message => 'Custom message')
-      expect(command.options.message).to eq('Custom message')
+      expect(message).to eq('Custom message')
     end
   end
 
   describe '#execute' do
     context 'when calling with a custom message' do
-      it 'sends the message when publishing' do
+      before(:all) do
         WebMock.stub_request(:post, 'https://api.apiary.io/blueprint/publish/myapi')
-        Apiary::Command::Publish.new(:api_name => 'myapi', :message => 'Custom message').execute
+        Apiary::Command::Publish.new({
+          :api_name => 'myapi',
+          :message => 'Custom message',
+          :path => './features/fixtures/apiary.apib'
+        }).execute
+      end
+
+      it 'sends the message when publishing' do
         expect(WebMock).to have_requested(:post, 'https://api.apiary.io/blueprint/publish/myapi').
           with {|request| request.body.include? 'messageToSave=Custom%20message'}
       end


### PR DESCRIPTION
This does not change the API, but is merely a fix where we pass the correct option through the HTTP POST.

I was testing this and figured I’d just fix while I was looking at it :)

cc @abtris 