### PR TITLE
fix: removed dependency 'public_suffix', '~> 1.4.6'

### DIFF
--- a/apiary.gemspec
+++ b/apiary.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'thor', '~> 0.19.1'
   gem.add_runtime_dependency 'json', '~> 1.8'
   gem.add_runtime_dependency 'launchy', '~> 2.4'
-  gem.add_runtime_dependency 'public_suffix', '~> 1.4.6'
 
   gem.add_development_dependency 'bundler', '~> 1.12'
   gem.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
https://github.com/apiaryio/apiary-client/issues/139