### PR TITLE
Update rest-client and rack to 2.0

### DIFF
--- a/apiary.gemspec
+++ b/apiary.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'rest-client', '~> 1.8'
-  gem.add_runtime_dependency 'rack', '~> 1.6.4'
+  gem.add_runtime_dependency 'rest-client', '~> 2.0'
+  gem.add_runtime_dependency 'rack', '~> 2.0'
   gem.add_runtime_dependency 'thor', '~> 0.19.1'
   gem.add_runtime_dependency 'json', '~> 1.8'
   gem.add_runtime_dependency 'launchy', '~> 2.4'

--- a/spec/apiary/command/publish_spec.rb
+++ b/spec/apiary/command/publish_spec.rb
@@ -38,7 +38,7 @@ describe Apiary::Command::Publish do
 
       it 'sends the message when publishing' do
         expect(WebMock).to have_requested(:post, 'https://api.apiary.io/blueprint/publish/myapi')
-          .with { |request| request.body.include? 'messageToSave=Custom%20message' }
+          .with { |request| request.body.include? 'messageToSave=Custom+message' }
       end
     end
   end


### PR DESCRIPTION
Otherwise, it's blocking upgrades. Maybe a safer alternative to #143. Passed all tests (encoding of spaces is different but equivalent).

See also: #135