### PR TITLE
Require yaml. Necessary for json to yaml conversion when publishing

### DIFF
--- a/lib/apiary/command/publish.rb
+++ b/lib/apiary/command/publish.rb
@@ -3,6 +3,7 @@ require 'rest-client'
 require 'rack'
 require 'ostruct'
 require 'json'
+require 'yaml'
 
 require 'apiary/agent'
 require 'apiary/helpers'


### PR DESCRIPTION
# Context
Refer #152, when publishing json an error is thrown as the to_yaml method can't be found.

# Specific changes
Adds single require statement to publish command. Local testing suggests this corrects the bad behaviour.

This is my first PR to one of your repo's, please let me know if you require more detail or what me to do anything additional. Thanks!