### PR TITLE
fix: Require yaml. Necessary for json to yaml conversion when publishing

### DIFF
--- a/lib/apiary/helpers.rb
+++ b/lib/apiary/helpers.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'yaml'
+
 module Apiary
   module Helpers
     def api_description_source_path(path)

--- a/lib/apiary/version.rb
+++ b/lib/apiary/version.rb
@@ -1,3 +1,3 @@
 module Apiary
-  VERSION = '0.8.0'.freeze
+  VERSION = '0.8.1'.freeze
 end


### PR DESCRIPTION
fixing https://github.com/apiaryio/apiary-client/issues/152