### PR TITLE
Enable server when watch is true

### DIFF
--- a/lib/apiary/command/preview.rb
+++ b/lib/apiary/command/preview.rb
@@ -49,7 +49,7 @@ module Apiary::Command
     end
 
     def execute
-      if @options.server
+      if @options.server || @options.watch
         watch
         server
       else


### PR DESCRIPTION
This allows the `--watch` command to work on its own, without you having to specify `--server` as well. As in, it will work as expected.