### PR TITLE
Bump the required version of thor. Rails 6 requires thor version 0.20.3

### DIFF
--- a/apiary.gemspec
+++ b/apiary.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'rest-client', '~> 2.0'
   gem.add_runtime_dependency 'rack', '~> 2.0.0'
-  gem.add_runtime_dependency 'thor', '~> 0.19.1'
+  gem.add_runtime_dependency 'thor', '~> 0.20.3'
   gem.add_runtime_dependency 'json', '~> 1.8'
   gem.add_runtime_dependency 'launchy', '~> 2.4'
   gem.add_runtime_dependency 'listen', '~> 2.0'


### PR DESCRIPTION
Rails 6 requires thor version v0.20.3 as seen here https://github.com/rails/rails/blob/0e8d85ddb54a7f08b027b2757c6678ebf74732d9/Gemfile.lock#L98

This PR updates the dependency to allow Apiary to be installed in Rails 6.