### PR TITLE
chore: Release 0.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Get the version
         id: version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
-      - name: Build and Release
+      - name: Docker Build and Release
         run: |
           docker build . -t apiaryio/client
           docker tag apiaryio/client apiaryio/client:${{ steps.version.outputs.VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.13.0
+## 0.14.0
 
 ### Breaking
 * Remove support for ruby 2.3

--- a/lib/apiary/version.rb
+++ b/lib/apiary/version.rb
@@ -1,3 +1,3 @@
 module Apiary
-  VERSION = '0.13.0'.freeze
+  VERSION = '0.14.0'.freeze
 end


### PR DESCRIPTION
Apparently 0.13.0 was already released but not tagged anywhere