### PR TITLE
fix: update bundler to 2.2.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine
+FROM ruby:2.7-alpine
 RUN apk add --update build-base && rm /var/cache/apk/*
 RUN gem install apiaryio
 ENTRYPOINT ["apiary"]

--- a/apiary.gemspec
+++ b/apiary.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'launchy', '~> 2.4'
   gem.add_runtime_dependency 'listen', '~> 3.0'
 
-  gem.add_development_dependency 'bundler', '~> 2.0'
+  gem.add_development_dependency 'bundler', '>= 2.2.11'
   gem.add_development_dependency 'rake', '>= 12.3.3'
   gem.add_development_dependency 'rspec', '~> 3.4'
   gem.add_development_dependency 'webmock', '>= 2.2.0'

--- a/lib/apiary/version.rb
+++ b/lib/apiary/version.rb
@@ -1,3 +1,3 @@
 module Apiary
-  VERSION = '0.15.0'.freeze
+  VERSION = '0.15.1'.freeze
 end


### PR DESCRIPTION
Fix for `rake release` to support OTP