### PR TITLE
Relax thor version specifier

### DIFF
--- a/apiary.gemspec
+++ b/apiary.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'rest-client', '~> 2.0'
   gem.add_runtime_dependency 'rack', '>= 2.2.3', '< 3'
-  gem.add_runtime_dependency 'thor', '~> 1.1.0'
+  gem.add_runtime_dependency 'thor', '~> 1.1'
   gem.add_runtime_dependency 'json', '>= 2.3.0'
   gem.add_runtime_dependency 'launchy', '~> 2.4'
   gem.add_runtime_dependency 'listen', '~> 3.0'


### PR DESCRIPTION
I have declared apiaryio in my app Gemfile, and it causes a deprecation warning.

The current version specifier in gemspec forces to use an outdated version of Thor that is generating the following deprecation warning when used with relatively recent version of did_you_mean, such the ones bundled with recent ruby versions.

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

Relaxing the version allows Thor to be updated to more recent minor versions and fixes the deprecation warning.