### PR TITLE
add ostruct dependency where json is required

### DIFF
--- a/lib/apiary/command/archive.rb
+++ b/lib/apiary/command/archive.rb
@@ -2,6 +2,7 @@
 
 require 'rest-client'
 require 'json'
+require 'ostruct'
 
 require 'apiary/agent'
 

--- a/lib/apiary/command/fetch.rb
+++ b/lib/apiary/command/fetch.rb
@@ -2,6 +2,7 @@
 
 require 'rest-client'
 require 'json'
+require 'ostruct'
 
 require 'apiary/agent'
 

--- a/lib/apiary/command/preview.rb
+++ b/lib/apiary/command/preview.rb
@@ -3,6 +3,7 @@
 require 'rest-client'
 require 'rack'
 require 'json'
+require 'ostruct'
 require 'tmpdir'
 require 'erb'
 require 'launchy'

--- a/lib/apiary/command/publish.rb
+++ b/lib/apiary/command/publish.rb
@@ -2,6 +2,7 @@
 
 require 'rest-client'
 require 'json'
+require 'ostruct'
 
 require 'apiary/agent'
 require 'apiary/helpers'

--- a/lib/apiary/command/styleguide.rb
+++ b/lib/apiary/command/styleguide.rb
@@ -2,6 +2,7 @@
 
 require 'rest-client'
 require 'json'
+require 'ostruct'
 
 require 'apiary/agent'
 require 'apiary/helpers'


### PR DESCRIPTION
The apiarycli seems to be broken ever since the json gem has been updated recently: https://github.com/flori/json/compare/v2.7.1...v2.7.2. This adds the ostruct dependency where json is required.